### PR TITLE
Improved autocompletion for htop

### DIFF
--- a/HTOP/htop.js
+++ b/HTOP/htop.js
@@ -180,10 +180,25 @@ const argsSchema = [
   ['fquit', false], // Force quit all previous ui elements.
 ];
 
+
+/**
+ * @param {{
+*      servers: string[];
+*      txts: string[];
+*      scripts: string[];
+*      flags: (schema: [string, string | number | boolean | string[]][]) => { [key: string]: string[] | ScriptArg; }
+* }} data
+* @param {string[]} args
+*/
 export function autocomplete(data, args) {
-  data.flags(argsSchema);
-  return [];
+ data.flags(argsSchema);
+ if (args.slice(args.length - 2).includes("--server")) {
+   return [...data.servers];
+ }
+
+ return [];
 }
+
 
 /** @param {NS} ns */
 export function die(ns) {

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-HTOP:1.2.1
+HTOP:1.2.2
 Git:1.0.5
 Testing:1.0.1


### PR DESCRIPTION
Basically if we recognize the `--server` option we give back the server list as autocompletion candidate